### PR TITLE
Fix file name case for gps.h

### DIFF
--- a/src/gps.cpp
+++ b/src/gps.cpp
@@ -16,7 +16,7 @@
  *  limitations under the License.
  */
 
-#include "GPS.h"
+#include "gps.h"
 #include "pins.h"
 #include "esp_log.h"
 #include "string.h"


### PR DESCRIPTION
The current code fails to compile on Unix-based OSs as GPS.h is not found - the case is wrong, the header name is gps.h